### PR TITLE
fix: avoid error with Symfony 6.4 LTS downgrade

### DIFF
--- a/config/packages/csrf.php
+++ b/config/packages/csrf.php
@@ -3,8 +3,14 @@
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    // This configutation file is specific to Symfony 7.2+
+    if (Kernel::VERSION_ID < 70200) {
+        return;
+    }
+
     // Enable stateless CSRF protection for forms and logins/logouts
     $containerConfigurator->extension('framework', [
         'form' => [


### PR DESCRIPTION
When downgrading to Symfony 6.4 LTS, avoid the error: 

```
!!  In ArrayNode.php line 327:
!!
!!    Unrecognized option "token_id" under "framework.form.csrf_protection". Avai
!!    lable options are "enabled", "field_name".
!!
!!
!!
Script @auto-scripts was called via post-update-cmd
```

| Q             | A
|---------------| ---
| Branch?       | main
| Cleanup?      | no 
| Bug fix?      | yes
| Fixed tickets | NA
| New feature?  | no 
| Doc added?    | no
| Tests pass?   | yes
| Deprecations? | no 
| License       | MIT

