### PR TITLE
doc: fix link to Laragon's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Open [https://localhost](https://localhost) and enjoy! 🙂
 
 ### With Laragon
 
-Check out the specific [documentation](https://github.com/strangebuzz/MicroSymfony?tab=laragon-ov-file).
+Check out the specific [documentation](https://github.com/strangebuzz/MicroSymfony/blob/main/docs/laragon.md).
 
 
 ## Requirements ⚙


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | main
| Cleanup?      | no 
| Bug fix?      | no
| Fixed tickets | no
| New feature?  | no 
| Doc added?    | no
| Tests pass?   | yes
| Deprecations? | no 
| License       | MIT

The previous link didn't work.

It may be related to https://github.com/orgs/community/discussions/70577

Also related to:

-  #171