### PR TITLE
refactor: removed useless AsController attributes

### DIFF
--- a/src/Controller/ComposerAction.php
+++ b/src/Controller/ComposerAction.php
@@ -6,15 +6,13 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Attribute\AsController;
-// use Symfony\Component\HttpKernel\Attribute\Cache;
+use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @see ComposerActionTest
  */
-#[AsController]
-// #[Cache(maxage: 3600, public: true)]
+#[Cache(maxage: 3600, public: true)]
 final class ComposerAction extends AbstractController
 {
     /**

--- a/src/Controller/FormAction.php
+++ b/src/Controller/FormAction.php
@@ -9,15 +9,11 @@ use App\Form\Type\RegisterForm;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Attribute\AsController;
-// use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @see FormActionTest
  */
-#[AsController]
-// #[Cache(maxage: 3600, public: true)]
 final class FormAction extends AbstractController
 {
     /**

--- a/src/Controller/HelloWorldAction.php
+++ b/src/Controller/HelloWorldAction.php
@@ -6,15 +6,13 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * We use the two binds we have defined in config/services.yaml.
+ * We use the two binds we have defined in config/services.php::49.
  */
-#[AsController]
-// #[Cache(maxage: 3600, public: true)]
+#[Cache(maxage: 3600, public: true)]
 final class HelloWorldAction extends AbstractController
 {
     #[Route(path: '/hello-world', name: self::class)]

--- a/src/Controller/HomeAction.php
+++ b/src/Controller/HomeAction.php
@@ -6,15 +6,16 @@ namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Attribute\AsController;
-// use Symfony\Component\HttpKernel\Attribute\Cache;
+// use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @see StaticActionTest
+ * @see StaticRoutesSmokeTest
  */
-#[AsController]
-// #[Cache(maxage: 3600, public: true)]
+// using the AsController attribute is not mandatory when extending the Symfony AbstractController or when using the #Route attribute.
+// #[AsController]
+#[Cache(maxage: 3600, public: true)]
 final class HomeAction extends AbstractController
 {
     /**

--- a/src/Controller/SlugifyAction.php
+++ b/src/Controller/SlugifyAction.php
@@ -7,7 +7,6 @@ namespace App\Controller;
 use App\Helper\StringHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -17,7 +16,6 @@ use Symfony\Component\Routing\Attribute\Route;
  * @see SlugifyActionTest
  * @see https://symfony.com/doc/current/controller/service.html#invokable-controllers
  */
-#[AsController]
 final class SlugifyAction extends AbstractController
 {
     /**


### PR DESCRIPTION
* https://symfony.com/doc/current/controller/service.html#using-the-ascontroller-attribute

| Q             | A
|---------------| ---
| Branch?       | main
| Cleanup?      | yes
| Bug fix?      | no
| Fixed tickets | NA
| New feature?  | no 
| Doc added?    | yes
| Tests pass?   | yes
| Deprecations? | no 
| License       | MIT
